### PR TITLE
EFAX-25 moved business logic from controller into service layer

### DIFF
--- a/mailservice-api/src/main/java/ca/bc/gov/ag/mail/MailController.java
+++ b/mailservice-api/src/main/java/ca/bc/gov/ag/mail/MailController.java
@@ -1,13 +1,9 @@
 package ca.bc.gov.ag.mail;
 
-import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Date;
-import java.util.List;
 
 import javax.validation.Valid;
 
-import org.apache.commons.collections4.ListUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,8 +15,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import ca.bc.gov.ag.exception.MailException;
 import ca.bc.gov.ag.model.MailMessage;
-import ca.bc.gov.ag.model.SentMessage;
-import ca.bc.gov.ag.repository.SentMessageRepository;
 
 /**
  * This {@link MailController} exposes the {@link MailService} in a REST API.
@@ -34,9 +28,6 @@ public class MailController {
     @Autowired
     private MailService mailService;
 
-    @Autowired
-    private SentMessageRepository sentMessageRepository;
-
     /**
      * This method accepts a {@link MailMessage} as a POST request to create and send an email using Microsoft Exchange server.
      * 
@@ -49,23 +40,10 @@ public class MailController {
         logger.debug("Request to /sendMessage, uuid: {}", mailMessage.getUuid());
 
         try {
-            List<String> attachments = ListUtils.emptyIfNull(mailMessage.getAttachments());
-            URI[] attachmentRefs = new URI[attachments.size()];
-            for (int i = 0; i < attachmentRefs.length; i++) {
-                attachmentRefs[i] = new URI(attachments.get(i));
-            }
-
-            // Store the UUID of this message in the redis queue. To avoid race conditions, this is stored now (before the actual sending of the
-            // message) and removed if there is an error.
-            SentMessage sentMessage = new SentMessage(mailMessage.getUuid(), mailMessage.getJobId(), new Date());
-            sentMessageRepository.save(sentMessage);
-
             mailService.sendMessage(mailMessage);
-
         } catch (Exception e) {
             logger.error("Error sending message, uuid: {}", mailMessage.getUuid());
             logger.error("Exception:", e);
-            sentMessageRepository.deleteById(mailMessage.getUuid());
             throw e;
         }
         logger.debug("Message pushed to ExchangeServer, uuid: {}", mailMessage.getUuid());

--- a/mailservice-api/src/main/java/ca/bc/gov/ag/mail/MailService.java
+++ b/mailservice-api/src/main/java/ca/bc/gov/ag/mail/MailService.java
@@ -9,6 +9,7 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.Date;
 import java.util.List;
 
 import javax.xml.rpc.ServiceException;
@@ -55,7 +56,9 @@ import com.microsoft.schemas.exchange.services._2006.types.holders.ServerVersion
 
 import ca.bc.gov.ag.exception.MailException;
 import ca.bc.gov.ag.model.MailMessage;
+import ca.bc.gov.ag.model.SentMessage;
 import ca.bc.gov.ag.pdf.PdfService;
+import ca.bc.gov.ag.repository.SentMessageRepository;
 import ca.bc.gov.ag.util.StringUtils;
 import ca.bc.gov.jag.ews.proxy.ExchangeWebServiceClient;
 
@@ -66,17 +69,26 @@ public class MailService {
     
 	@Autowired
 	private MailProperties mailProperties;
-	
+
+    @Autowired
+    private SentMessageRepository sentMessageRepository;
+    
 	@Autowired
 	private PdfService pdfService;
 	
-	public void sendMessage(final MailMessage mailMessage) throws MailException {
-		try {
-			processMessage(mailMessage);
-		} catch (Exception e) {
-			throw new MailException("Unknown Exception in class sendMessage", e);
-		}
-	}
+    public void sendMessage(final MailMessage mailMessage) throws MailException {
+        try {
+            // Store the UUID of this message in the redis queue. To avoid race conditions, this is stored now (before the actual sending of the
+            // message) and removed if there is an error.
+            SentMessage sentMessage = new SentMessage(mailMessage.getUuid(), mailMessage.getJobId(), new Date());
+            sentMessageRepository.save(sentMessage);
+
+            processMessage(mailMessage);
+        } catch (Exception e) {
+            sentMessageRepository.deleteById(mailMessage.getUuid());
+            throw new MailException("Unknown Exception in class sendMessage", e);
+        }
+    }
 
 	// Post processing cleanup
 	// Delete temp attachment(s) file(s)


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

https://justice.gov.bc.ca/jira/browse/EFAX-25

Business logic should not exist in controllers, that's what the service layer is for.

Moved the logic of storing the sent message in redis (to check for timeouts) from the main controller to the service layer.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

mvn verify

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
