### PR TITLE
EFAX-24 created an email poller, listening for incoming messages from MS

### DIFF
--- a/src/main/java/ca/bc/gov/ag/efax/mail/config/ExchangeConfiguration.java
+++ b/src/main/java/ca/bc/gov/ag/efax/mail/config/ExchangeConfiguration.java
@@ -5,19 +5,28 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import ca.bc.gov.ag.efax.mail.service.ExchangeServiceFactory;
+import ca.bc.gov.ag.efax.mail.service.parser.EmailParser;
+import ca.bc.gov.ag.efax.mail.service.parser.UndeliverableVisitor;
 
 @Configuration
 @EnableConfigurationProperties(ExchangeProperties.class)
 public class ExchangeConfiguration {
 
-	@Bean
-	public ExchangeProperties exchangeProperties(ExchangeProperties exchangeProperties) {
-		return exchangeProperties;
-	}
+    @Bean
+    public ExchangeProperties exchangeProperties(ExchangeProperties exchangeProperties) {
+        return exchangeProperties;
+    }
 
     @Bean
     public ExchangeServiceFactory exchangeConfig(ExchangeProperties exchangeProperties) {
         return new ExchangeServiceFactory(exchangeProperties);
     }
-	
+
+    @Bean
+    public EmailParser emailParser() {
+        EmailParser emailParser = new EmailParser();
+        emailParser.registerVisitor(new UndeliverableVisitor());
+        return emailParser;
+    }
+
 }

--- a/src/main/java/ca/bc/gov/ag/efax/mail/scheduler/EmailPoller.java
+++ b/src/main/java/ca/bc/gov/ag/efax/mail/scheduler/EmailPoller.java
@@ -1,7 +1,6 @@
 package ca.bc.gov.ag.efax.mail.scheduler;
 
-import java.util.List;
-
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,32 +8,48 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import ca.bc.gov.ag.dist.efax.ws.model.DocumentDistributionMainProcessProcessUpdate;
 import ca.bc.gov.ag.efax.mail.service.EmailService;
+import ca.bc.gov.ag.efax.mail.service.parser.EmailParser;
 import microsoft.exchange.webservices.data.core.service.item.EmailMessage;
 
 @Component
 public class EmailPoller {
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
-    
+
     @Autowired
     private EmailService emailService;
-    
+
+    @Autowired
+    private EmailParser emailParser;
+
     @Value(value = "${exchange.poller.enabled}")
     private boolean enabled;
-    
+
     @Scheduled(fixedDelayString = "${exchange.poller.interval}")
     public void pollForEmails() throws Exception {
         if (!enabled) {
             return;
         }
-        
+
         logger.debug("Started email inbox poll.");
-        
-        List<EmailMessage> emailMessages = emailService.getEfaxInboxEmails();        
-        
-        // TODO: EFAX-24 parse emails, looking for jobId and status of the sent fax
+
+        // Retrieve all INBOX emails (that was originally sent to IMCEAFAX) 
+        for (EmailMessage emailMessage : emailService.getEfaxInboxEmails()) {
+            
+            // Attempt to parse the email response from MS Exchange
+            DocumentDistributionMainProcessProcessUpdate response = emailParser.parse(emailMessage);
+
+            // If the jobId is blank, there's nothing we can do except move on. (We can't send a message to the Justin Callback informing the user
+            // that a message with a certain jobId succeeded or failed).  If so, an error message should have been logged for review so the email
+            // parser can be improved upon.
+            if (!StringUtils.isEmpty(response.getJobId())) {                     
+                // TODO: send message to Justin Callback informing user of the jobId and status.
+            }
+        }
+
         logger.debug("Finished email inbox poll.");
     }
-    
+
 }

--- a/src/main/java/ca/bc/gov/ag/efax/mail/service/ExchangeServiceFactory.java
+++ b/src/main/java/ca/bc/gov/ag/efax/mail/service/ExchangeServiceFactory.java
@@ -36,4 +36,5 @@ public class ExchangeServiceFactory {
                 exchangeProperties.getPassword());
         return client;
     }
+    
 }

--- a/src/main/java/ca/bc/gov/ag/efax/mail/service/parser/EmailParser.java
+++ b/src/main/java/ca/bc/gov/ag/efax/mail/service/parser/EmailParser.java
@@ -1,0 +1,73 @@
+package ca.bc.gov.ag.efax.mail.service.parser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ca.bc.gov.ag.dist.efax.ws.model.DocumentDistributionMainProcessProcessUpdate;
+import ca.bc.gov.ag.efax.mail.util.DateUtil;
+import ca.bc.gov.ag.efax.ws.exception.FAXListenFault;
+import microsoft.exchange.webservices.data.core.service.item.EmailMessage;
+import microsoft.exchange.webservices.data.property.complex.MessageBody;
+
+public class EmailParser {
+
+    private final Logger logger = LoggerFactory.getLogger(EmailParser.class);
+
+    private List<EmailVisitor> visitors = new ArrayList<EmailVisitor>();
+
+    /** Registers (adds) an EmailVisitor to this parser. */
+    public void registerVisitor(EmailVisitor visitor) {
+        visitors.add(visitor);
+    }
+
+    /**
+     * Attempts to parse the emailMessage, extracting the jobId, uuid, and status.
+     * 
+     * @param emailMessage
+     * @return
+     * @throws Exception
+     */
+    public DocumentDistributionMainProcessProcessUpdate parse(EmailMessage emailMessage) throws Exception {
+        DocumentDistributionMainProcessProcessUpdate response = new DocumentDistributionMainProcessProcessUpdate();
+        response.setDateTime(DateUtil.toXMLGregorianCalendar(emailMessage.getDateTimeReceived()));
+
+        String subject = emailMessage.getSubject();
+        String body = MessageBody.getStringFromMessageBody(emailMessage.getBody());
+
+        // Try every registered email visitor to see if we can parse the email response from MS Exchange.
+        for (EmailVisitor emailParserVisitor : visitors) {
+            if (hasJobId(response))
+                break;
+            emailParserVisitor.apply(subject, body, response);
+        }
+
+        if (!hasJobId(response)) {
+            // Could not parse email. Log the email as an error rather than throwing an exception so control can flow to the next email 
+            // which may not have an issue.
+            logger.error("Unrecognized email, \nsubject: [{}], \nbody: [{}]", subject, body);
+        }
+
+        // Default error to FAXListenFault if a jobId was found, but could not parse a status.
+        else if (!hasStatus(response)) {
+            logger.error("Unrecognized email, could not find status, \nsubject: [{}], \nbody: [{}]", subject, body);
+            FAXListenFault faxListenFault = new FAXListenFault();
+            response.setStatus(faxListenFault.getFaultCode());
+            response.setStatus(faxListenFault.getFaultMessage());
+        }
+
+        return response;
+    }
+
+    private boolean hasJobId(DocumentDistributionMainProcessProcessUpdate response) {
+        return !StringUtils.isEmpty(response.getJobId());
+    }
+
+    private boolean hasStatus(DocumentDistributionMainProcessProcessUpdate response) {
+        return !StringUtils.isEmpty(response.getJobId());
+    }
+
+}

--- a/src/main/java/ca/bc/gov/ag/efax/mail/service/parser/EmailVisitor.java
+++ b/src/main/java/ca/bc/gov/ag/efax/mail/service/parser/EmailVisitor.java
@@ -1,0 +1,9 @@
+package ca.bc.gov.ag.efax.mail.service.parser;
+
+import ca.bc.gov.ag.dist.efax.ws.model.DocumentDistributionMainProcessProcessUpdate;
+
+public interface EmailVisitor {
+
+    public void apply(String subject, String body, DocumentDistributionMainProcessProcessUpdate response);
+    
+}

--- a/src/main/java/ca/bc/gov/ag/efax/mail/service/parser/UndeliverableVisitor.java
+++ b/src/main/java/ca/bc/gov/ag/efax/mail/service/parser/UndeliverableVisitor.java
@@ -1,0 +1,33 @@
+package ca.bc.gov.ag.efax.mail.service.parser;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ca.bc.gov.ag.dist.efax.ws.model.DocumentDistributionMainProcessProcessUpdate;
+import ca.bc.gov.ag.efax.ws.exception.FAXListenFault;
+
+public class UndeliverableVisitor implements EmailVisitor {
+
+    private final static Logger logger = LoggerFactory.getLogger(UndeliverableVisitor.class);
+    
+    /** A regex pattern for the expected subject line of an undeliverable fax */
+    private static final String UNDELIVERABLE = "Undeliverable: <jobId>(\\d+)</jobId><uuid>(.+)</uuid>";
+
+    @Override
+    public void apply(String subject, String body, DocumentDistributionMainProcessProcessUpdate response) {
+        if (Pattern.matches(UNDELIVERABLE, subject)) {
+            Matcher matcher = Pattern.compile(UNDELIVERABLE).matcher(subject);
+            if (matcher.find()) {
+                FAXListenFault fault = new FAXListenFault();
+                response.setStatus(fault.getFaultCode());
+                response.setStatusMsg(fault.getFaultMessage());
+                response.setJobId(matcher.group(1));
+                response.setUuid(matcher.group(2));
+                logger.error("Undeliverable email, \nsubject: [{}], \nbody: [{}]", subject, body);
+            }
+        }
+    }
+}

--- a/src/main/java/ca/bc/gov/ag/efax/mail/util/DateUtil.java
+++ b/src/main/java/ca/bc/gov/ag/efax/mail/util/DateUtil.java
@@ -1,0 +1,25 @@
+package ca.bc.gov.ag.efax.mail.util;
+
+import java.util.Date;
+import java.util.GregorianCalendar;
+
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.datatype.XMLGregorianCalendar;
+
+public class DateUtil {
+
+    /**
+     * Converts a standard java.util.Date to a java.util.XMLGregorianCalendar.
+     * 
+     * @param date
+     * @return
+     * @throws DatatypeConfigurationException if the DatatypeFactory could not be instantiated.
+     */
+    public static XMLGregorianCalendar toXMLGregorianCalendar(Date date) throws DatatypeConfigurationException {
+        GregorianCalendar gc = new GregorianCalendar();
+        gc.setTime(date);
+        return DatatypeFactory.newInstance().newXMLGregorianCalendar(gc);
+    }
+
+}

--- a/src/main/java/ca/bc/gov/ag/efax/ws/config/SpringContext.java
+++ b/src/main/java/ca/bc/gov/ag/efax/ws/config/SpringContext.java
@@ -25,6 +25,14 @@ public class SpringContext implements ApplicationContextAware {
 	public static <T extends Object> T getBean(Class<T> beanClass) {
 		return context.getBean(beanClass);
 	}
+	
+	/**
+	 * Returns the ApplicationContext for spring instance.
+	 * @return
+	 */
+	public static ApplicationContext getApplicationContext() {
+	    return context;
+	}
 
 	@Override
 	public void setApplicationContext(ApplicationContext context) throws BeansException {

--- a/src/main/java/ca/bc/gov/ag/efax/ws/exception/FAXListenFault.java
+++ b/src/main/java/ca/bc/gov/ag/efax/ws/exception/FAXListenFault.java
@@ -4,6 +4,10 @@ public class FAXListenFault extends ServiceFaultException {
 
     private static final long serialVersionUID = 1L;
 
+    public FAXListenFault() {
+        super(FaultId.FAX_LISTEN_FAULT);
+    }
+    
     public FAXListenFault(String jobId, String message) {
         super(FaultId.FAX_LISTEN_FAULT, jobId, message);
     }

--- a/src/main/java/ca/bc/gov/ag/efax/ws/exception/ServiceFaultException.java
+++ b/src/main/java/ca/bc/gov/ag/efax/ws/exception/ServiceFaultException.java
@@ -12,6 +12,10 @@ public abstract class ServiceFaultException extends RuntimeException {
     private String jobId;
     private FaultId faultId;
     
+    public ServiceFaultException(FaultId faultId) {
+        this(faultId, null, null);
+    }
+    
     public ServiceFaultException(FaultId faultId, String jobId, String message) {
         super(message);
         this.faultId = faultId;
@@ -31,6 +35,14 @@ public abstract class ServiceFaultException extends RuntimeException {
         fault.setFaultCode(serviceFault.getCode());
         fault.setFaultMessage(serviceFault.getMessage());
         return fault;
+    }
+    
+    public String getFaultCode() {
+        return getProcessFault().getFaultCode();
+    }
+    
+    public String getFaultMessage() {
+        return getProcessFault().getFaultMessage();
     }
 
     protected enum FaultId {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -19,7 +19,9 @@ exchange:
   poller:  
     enabled: true
     # Interval (in milliseconds) of how often to poll the exchange server email inbox  
-    interval: 300000    # 5 minutes 
+    interval: 300000    # 5 minutes
+    # A search filter to apply to incoming emails. 
+    filter: "to:IMCEAFAX" # all emails that where sent to an address starting with IMCEAFAX (which is the faxformat prefix)
 
 aem: # AEM is a PDF flattening service
   endpoint: ${PDF_ENDPOINT}
@@ -35,6 +37,8 @@ ws:
   
   # Interval (in milliseconds) when to poll/check for timed-out sent faxes.
   faxTimeoutCheck: 60000 # 60 seconds
+  
+  callbackEndpoint: ${CALLBACK_ENDPOINT:}
   
   # These are the SOAP faults returned for various reasons.
   faults:


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

https://justice.gov.bc.ca/jira/browse/EFAX-24

Created a scheduled task that polls the INBOX of an Exchange server looking for a response from exchange to it's attempt to send a fax message.  Such emails are addressed to IMCEAFAX...

Once the emails have been received, they are parsed, looking for the jobId and status of the fax attempt.
Using a Visitor design pattern there is a registered set of matchers that will attempt to parse the incoming email.
Currently, the only response I know of is an Undeliverable response, but this will be expanded upon once the system works.

- Added an EmailParser bean to parse emails from exchange.
- Added an EmailPoller, a class with a scheduled method to poll the exchange server
- Added a to:IMCEAFAX filter when looking for inbox emails



## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

mvn verify

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
