### PR TITLE
disabled email poller schedule task when running tests

### DIFF
--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -9,4 +9,5 @@ exchange:
     endpoint: ${EXCHANGE_ENDPOINT:http://localhost}
     username: ${EXCHANGE_USERNAME:username}
     password: ${EXCHANGE_PASSWORD:password}
-
+  poller:  
+    enabled: false


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

Disabled the Scheduled email poller task when running junit tests.  We aren't able to run this task until we have mock services that replicate Exchange.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

`mvn verify` no longer spits out connection errors.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
