### PR TITLE
EFAX-24 moved processed emails to the "Deleted Items" folder

### DIFF
--- a/src/main/java/ca/bc/gov/ag/efax/mail/scheduler/EmailPoller.java
+++ b/src/main/java/ca/bc/gov/ag/efax/mail/scheduler/EmailPoller.java
@@ -40,7 +40,7 @@ public class EmailPoller {
         logger.debug("Started email inbox poll.");
 
         // Retrieve all INBOX emails (that was originally sent to IMCEAFAX) 
-        for (EmailMessage emailMessage : emailService.getEfaxInboxEmails()) {
+        for (EmailMessage emailMessage : emailService.getInboxEmails()) {
             
             // Attempt to parse the email response from MS Exchange
             DocumentDistributionMainProcessProcessUpdate response = emailParser.parse(emailMessage);
@@ -52,7 +52,8 @@ public class EmailPoller {
                 documentDistributionService.sendResponseToCallback(response);
             }
             
-            // TODO: delete the email / move to a "processed" folder so we don't process this same email again.
+            // Move email to the "Deleted Items" folder so we don't process this same email again.
+            emailService.deleteEmail(emailMessage);
         }
 
         logger.debug("Finished email inbox poll.");

--- a/src/main/java/ca/bc/gov/ag/efax/mail/service/EmailService.java
+++ b/src/main/java/ca/bc/gov/ag/efax/mail/service/EmailService.java
@@ -13,7 +13,14 @@ public interface EmailService {
      * @return
      * @throws Exception 
      */
-    List<EmailMessage> getEfaxInboxEmails() throws Exception;
+    List<EmailMessage> getInboxEmails() throws Exception;
+
+    /**
+     * Moves the specified email to the "Deleted Items" folder
+     * @param emailMessage
+     * @throws Exception 
+     */
+    void deleteEmail(EmailMessage emailMessage) throws Exception;
     
     /**
      * Sends an email (including any attachments) using Microsoft Exchange.

--- a/src/main/java/ca/bc/gov/ag/efax/mail/service/EmailServiceImpl.java
+++ b/src/main/java/ca/bc/gov/ag/efax/mail/service/EmailServiceImpl.java
@@ -66,6 +66,7 @@ import microsoft.exchange.webservices.data.core.ExchangeService;
 import microsoft.exchange.webservices.data.core.PropertySet;
 import microsoft.exchange.webservices.data.core.enumeration.property.WellKnownFolderName;
 import microsoft.exchange.webservices.data.core.enumeration.search.SortDirection;
+import microsoft.exchange.webservices.data.core.enumeration.service.DeleteMode;
 import microsoft.exchange.webservices.data.core.service.item.EmailMessage;
 import microsoft.exchange.webservices.data.core.service.item.Item;
 import microsoft.exchange.webservices.data.core.service.schema.ItemSchema;
@@ -94,7 +95,7 @@ public class EmailServiceImpl implements EmailService {
     private String filter;
    
     @Override
-    public List<EmailMessage> getEfaxInboxEmails() throws Exception {    
+    public List<EmailMessage> getInboxEmails() throws Exception {    
         logger.trace("Retrieving inbox emails");
         ItemView view = new ItemView(Integer.MAX_VALUE);
         view.getOrderBy().add(ItemSchema.DateTimeReceived, SortDirection.Ascending);
@@ -109,6 +110,12 @@ public class EmailServiceImpl implements EmailService {
         List<EmailMessage> emailMessages = emails.getItems().stream().map(item -> (EmailMessage) item).collect(Collectors.toList());
         logger.trace("Retrieved {} emails", emailMessages.size());
         return emailMessages;
+    }
+    
+    @Override
+    public void deleteEmail(EmailMessage emailMessage) throws Exception {
+        ExchangeService exchangeService = exchangeServiceFactory.createService();
+        exchangeService.deleteItem(emailMessage.getId(), DeleteMode.MoveToDeletedItems, null, null);        
     }
 
     @Override


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

https://justice.gov.bc.ca/jira/browse/EFAX-24
Moved processed emails to the "Deleted Items" folder so we don't keep processing the same email again and again.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Ran the application and confirmed the deletion actually works.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
