### PR TITLE
EFAX-24 fixed fault message for undeliverable faxes

### DIFF
--- a/src/main/java/ca/bc/gov/ag/efax/mail/service/parser/EmailParser.java
+++ b/src/main/java/ca/bc/gov/ag/efax/mail/service/parser/EmailParser.java
@@ -7,7 +7,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import ca.bc.gov.ag.efax.ws.exception.FAXListenFault;
+import ca.bc.gov.ag.efax.ws.exception.FAXSendFault;
 import ca.bc.gov.ag.efax.ws.model.DocumentDistributionMainProcessProcessResponse;
 import microsoft.exchange.webservices.data.core.service.item.EmailMessage;
 import microsoft.exchange.webservices.data.property.complex.MessageBody;
@@ -49,10 +49,10 @@ public class EmailParser {
             logger.error("Unrecognized email, \nsubject: [{}]", subject);
         }
 
-        // Default error to FAXListenFault if a jobId was found, but could not parse a status.
+        // Default error to FAXSendFault if a jobId was found, but could not parse a status.
         else if (!hasStatus(response)) {
             logger.error("Unrecognized email, could not find status, \nsubject: [{}]", subject);
-            FAXListenFault faxListenFault = new FAXListenFault();
+            FAXSendFault faxListenFault = new FAXSendFault();
             response.setStatusCode(faxListenFault.getFaultCode());
             response.setStatusMessage(faxListenFault.getFaultMessage());
         }

--- a/src/main/java/ca/bc/gov/ag/efax/mail/service/parser/UndeliverableVisitor.java
+++ b/src/main/java/ca/bc/gov/ag/efax/mail/service/parser/UndeliverableVisitor.java
@@ -6,7 +6,7 @@ import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import ca.bc.gov.ag.efax.ws.exception.FAXListenFault;
+import ca.bc.gov.ag.efax.ws.exception.FAXSendFault;
 import ca.bc.gov.ag.efax.ws.model.DocumentDistributionMainProcessProcessResponse;
 
 public class UndeliverableVisitor implements EmailVisitor {
@@ -21,7 +21,7 @@ public class UndeliverableVisitor implements EmailVisitor {
         if (Pattern.matches(UNDELIVERABLE, subject)) {
             Matcher matcher = Pattern.compile(UNDELIVERABLE).matcher(subject);
             if (matcher.find()) {
-                FAXListenFault fault = new FAXListenFault();
+                FAXSendFault fault = new FAXSendFault();
                 response.setJobId(matcher.group(1));
                 response.setStatusCode(fault.getFaultCode());
                 response.setStatusMessage(fault.getFaultMessage());

--- a/src/main/java/ca/bc/gov/ag/efax/ws/exception/FAXListenFault.java
+++ b/src/main/java/ca/bc/gov/ag/efax/ws/exception/FAXListenFault.java
@@ -3,10 +3,6 @@ package ca.bc.gov.ag.efax.ws.exception;
 public class FAXListenFault extends ServiceFaultException {
 
     private static final long serialVersionUID = 1L;
-
-    public FAXListenFault() {
-        super(FaultId.FAX_LISTEN_FAULT);
-    }
     
     public FAXListenFault(String jobId, String message) {
         super(FaultId.FAX_LISTEN_FAULT, jobId, message);

--- a/src/main/java/ca/bc/gov/ag/efax/ws/exception/FAXSendFault.java
+++ b/src/main/java/ca/bc/gov/ag/efax/ws/exception/FAXSendFault.java
@@ -4,6 +4,10 @@ public class FAXSendFault extends ServiceFaultException {
 
     private static final long serialVersionUID = 1L;
 
+    public FAXSendFault() {
+        super(FaultId.FAX_SEND_FAULT);
+    }
+    
     public FAXSendFault(String message) {
         super(FaultId.FAX_SEND_FAULT, message);
     }

--- a/src/test/java/ca/bc/gov/ag/efax/mail/service/parser/EmailParserTest.java
+++ b/src/test/java/ca/bc/gov/ag/efax/mail/service/parser/EmailParserTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import ca.bc.gov.ag.efax.BaseTestSuite;
-import ca.bc.gov.ag.efax.ws.exception.FAXListenFault;
+import ca.bc.gov.ag.efax.ws.exception.FAXSendFault;
 import ca.bc.gov.ag.efax.ws.model.DocumentDistributionMainProcessProcessResponse;
 import microsoft.exchange.webservices.data.core.service.item.EmailMessage;
 import microsoft.exchange.webservices.data.property.complex.MessageBody;
@@ -37,7 +37,7 @@ public class EmailParserTest extends BaseTestSuite {
                 
         DocumentDistributionMainProcessProcessResponse response = emailParser.parse(emailMessage);
 
-        FAXListenFault fault = new FAXListenFault();
+        FAXSendFault fault = new FAXSendFault();
         assertEquals("1234", response.getJobId()); // should have extracted the jobId from the subject
         assertEquals(fault.getFaultCode(), response.getStatusCode());
         assertEquals(fault.getFaultMessage(), response.getStatusMessage());

--- a/src/test/java/ca/bc/gov/ag/efax/mail/service/parser/UndeliverableVisitorTest.java
+++ b/src/test/java/ca/bc/gov/ag/efax/mail/service/parser/UndeliverableVisitorTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import org.junit.jupiter.api.Test;
 
 import ca.bc.gov.ag.efax.BaseTestSuite;
-import ca.bc.gov.ag.efax.ws.exception.FAXListenFault;
+import ca.bc.gov.ag.efax.ws.exception.FAXSendFault;
 import ca.bc.gov.ag.efax.ws.model.DocumentDistributionMainProcessProcessResponse;
 
 public class UndeliverableVisitorTest extends BaseTestSuite {
@@ -32,7 +32,7 @@ public class UndeliverableVisitorTest extends BaseTestSuite {
         visitor.apply(subject, "", response);
 
         // should match FAXListenFault
-        FAXListenFault fault = new FAXListenFault();
+        FAXSendFault fault = new FAXSendFault();
         assertEquals("1234", response.getJobId()); // should have extracted the jobId from the subject
         assertEquals(fault.getFaultCode(), response.getStatusCode());
         assertEquals(fault.getFaultMessage(), response.getStatusMessage());


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

EFAX-24 fixed the fault message sent for undeliverable faxes (should be send fault, not listen fault)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
