### PR TITLE
EFAX-24 removed msg from redis q after email poll

### DIFF
--- a/src/main/java/ca/bc/gov/ag/efax/mail/model/DocumentDistributionMainProcessProcessResponseDecorator.java
+++ b/src/main/java/ca/bc/gov/ag/efax/mail/model/DocumentDistributionMainProcessProcessResponseDecorator.java
@@ -1,0 +1,18 @@
+package ca.bc.gov.ag.efax.mail.model;
+
+import ca.bc.gov.ag.efax.ws.model.DocumentDistributionMainProcessProcessResponse;
+
+/** A wrapper class of the generated DocumentDistributionMainProcessProcessResponse object. */
+public class DocumentDistributionMainProcessProcessResponseDecorator extends DocumentDistributionMainProcessProcessResponse {
+
+    private String uuid;
+    
+    public String getUuid() {
+        return uuid;
+    }
+    
+    public void setUuid(String uuid) {
+        this.uuid = uuid;
+    }
+
+}

--- a/src/main/java/ca/bc/gov/ag/efax/mail/scheduled/EmailPoller.java
+++ b/src/main/java/ca/bc/gov/ag/efax/mail/scheduled/EmailPoller.java
@@ -8,9 +8,10 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import ca.bc.gov.ag.efax.mail.model.DocumentDistributionMainProcessProcessResponseDecorator;
+import ca.bc.gov.ag.efax.mail.repository.SentMessageRepository;
 import ca.bc.gov.ag.efax.mail.service.EmailService;
 import ca.bc.gov.ag.efax.mail.service.parser.EmailParser;
-import ca.bc.gov.ag.efax.ws.model.DocumentDistributionMainProcessProcessResponse;
 import ca.bc.gov.ag.efax.ws.service.DocumentDistributionService;
 import microsoft.exchange.webservices.data.core.service.item.EmailMessage;
 
@@ -32,6 +33,9 @@ public class EmailPoller {
     @Autowired
     private DocumentDistributionService documentDistributionService;
 
+    @Autowired
+    private SentMessageRepository sentMessageRepository;
+
     @Scheduled(fixedDelayString = "${exchange.poller.interval}")
     public void pollForEmails() throws Exception {
         logger.debug("Started email inbox poll.");
@@ -40,13 +44,16 @@ public class EmailPoller {
         for (EmailMessage emailMessage : emailService.getInboxEmails()) {
             
             // Attempt to parse the email response from MS Exchange
-            DocumentDistributionMainProcessProcessResponse response = emailParser.parse(emailMessage);
+            DocumentDistributionMainProcessProcessResponseDecorator response = emailParser.parse(emailMessage);
 
             // If the jobId is blank, there's nothing we can do except move on. (We can't send a message to the Justin Callback informing the user
             // that a message with a certain jobId succeeded or failed).  If so, an error message should have been logged for review so the email
             // parser can be improved upon.
             if (!StringUtils.isEmpty(response.getJobId())) {                     
                 documentDistributionService.sendResponseToCallback(response);
+                
+                // remove the referenced message from the redis queue
+                removeFromQueue(response.getUuid());
             }
             
             // Move email to the "Deleted Items" folder so we don't process this same email again.
@@ -56,4 +63,16 @@ public class EmailPoller {
         logger.debug("Finished email inbox poll.");
     }
 
+    /**
+     * Removes from the redis queue the record with the named id
+     * @param uuid
+     */
+    private void removeFromQueue(String uuid) {
+        try {
+            sentMessageRepository.deleteById(uuid);
+        } catch (Exception e) {
+            logger.error("Could not remove message with uuid '{}' from queue", uuid);
+            // Do nothing. The queued item will get removed when the faxTimeout scheduled task runs.
+        }
+    }
 }

--- a/src/main/java/ca/bc/gov/ag/efax/mail/service/parser/EmailParser.java
+++ b/src/main/java/ca/bc/gov/ag/efax/mail/service/parser/EmailParser.java
@@ -7,6 +7,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import ca.bc.gov.ag.efax.mail.model.DocumentDistributionMainProcessProcessResponseDecorator;
 import ca.bc.gov.ag.efax.ws.exception.FAXSendFault;
 import ca.bc.gov.ag.efax.ws.model.DocumentDistributionMainProcessProcessResponse;
 import microsoft.exchange.webservices.data.core.service.item.EmailMessage;
@@ -30,8 +31,8 @@ public class EmailParser {
      * @return
      * @throws Exception
      */
-    public DocumentDistributionMainProcessProcessResponse parse(EmailMessage emailMessage) throws Exception {
-        DocumentDistributionMainProcessProcessResponse response = new DocumentDistributionMainProcessProcessResponse();
+    public DocumentDistributionMainProcessProcessResponseDecorator parse(EmailMessage emailMessage) throws Exception {
+        DocumentDistributionMainProcessProcessResponseDecorator response = new DocumentDistributionMainProcessProcessResponseDecorator();
 
         String subject = emailMessage.getSubject();
         String body = MessageBody.getStringFromMessageBody(emailMessage.getBody());
@@ -44,8 +45,8 @@ public class EmailParser {
         }
 
         if (!hasJobId(response)) {
-            // Could not parse email. Log the email as an error rather than throwing an exception so control can flow to the next email 
-            // which may not have an issue.
+            // Could not parse email (could not find jobId). Log the email as an error rather than throwing an exception so 
+            // control can flow to the next email which may not have an issue.
             logger.error("Unrecognized email, \nsubject: [{}]", subject);
         }
 

--- a/src/main/java/ca/bc/gov/ag/efax/mail/service/parser/EmailVisitor.java
+++ b/src/main/java/ca/bc/gov/ag/efax/mail/service/parser/EmailVisitor.java
@@ -1,9 +1,9 @@
 package ca.bc.gov.ag.efax.mail.service.parser;
 
-import ca.bc.gov.ag.efax.ws.model.DocumentDistributionMainProcessProcessResponse;
+import ca.bc.gov.ag.efax.mail.model.DocumentDistributionMainProcessProcessResponseDecorator;
 
 public interface EmailVisitor {
 
-    public void apply(String subject, String body, DocumentDistributionMainProcessProcessResponse response);
+    public void apply(String subject, String body, DocumentDistributionMainProcessProcessResponseDecorator response);
     
 }

--- a/src/main/java/ca/bc/gov/ag/efax/mail/service/parser/UndeliverableVisitor.java
+++ b/src/main/java/ca/bc/gov/ag/efax/mail/service/parser/UndeliverableVisitor.java
@@ -6,8 +6,8 @@ import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import ca.bc.gov.ag.efax.mail.model.DocumentDistributionMainProcessProcessResponseDecorator;
 import ca.bc.gov.ag.efax.ws.exception.FAXSendFault;
-import ca.bc.gov.ag.efax.ws.model.DocumentDistributionMainProcessProcessResponse;
 
 public class UndeliverableVisitor implements EmailVisitor {
 
@@ -17,12 +17,13 @@ public class UndeliverableVisitor implements EmailVisitor {
     private static final String UNDELIVERABLE = "Undeliverable: <jobId>(\\d+)</jobId><uuid>(.+)</uuid>";
 
     @Override
-    public void apply(String subject, String body, DocumentDistributionMainProcessProcessResponse response) {
+    public void apply(String subject, String body, DocumentDistributionMainProcessProcessResponseDecorator response) {
         if (Pattern.matches(UNDELIVERABLE, subject)) {
             Matcher matcher = Pattern.compile(UNDELIVERABLE).matcher(subject);
             if (matcher.find()) {
                 FAXSendFault fault = new FAXSendFault();
                 response.setJobId(matcher.group(1));
+                response.setUuid(matcher.group(2));
                 response.setStatusCode(fault.getFaultCode());
                 response.setStatusMessage(fault.getFaultMessage());
                 logger.error("Undeliverable email, \nsubject: [{}]", subject);

--- a/src/test/java/ca/bc/gov/ag/efax/mail/scheduled/EmailPollerTest.java
+++ b/src/test/java/ca/bc/gov/ag/efax/mail/scheduled/EmailPollerTest.java
@@ -1,0 +1,71 @@
+package ca.bc.gov.ag.efax.mail.scheduled;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import ca.bc.gov.ag.efax.BaseTestSuite;
+import ca.bc.gov.ag.efax.mail.model.DocumentDistributionMainProcessProcessResponseDecorator;
+import ca.bc.gov.ag.efax.mail.model.SentMessage;
+import ca.bc.gov.ag.efax.mail.service.EmailService;
+import ca.bc.gov.ag.efax.mail.service.parser.EmailParser;
+import ca.bc.gov.ag.efax.mail.util.DateUtil;
+import ca.bc.gov.ag.efax.ws.service.DocumentDistributionService;
+import microsoft.exchange.webservices.data.core.service.item.EmailMessage;
+
+public class EmailPollerTest extends BaseTestSuite {
+    
+    @InjectMocks
+    private EmailPoller emailPoller;
+
+    @Mock
+    private EmailService emailService;
+
+    @Mock
+    private EmailParser emailParser;
+
+    @Mock
+    private DocumentDistributionService documentDistributionService;
+    
+    @BeforeEach
+    protected void beforeEach() throws Exception {
+        super.beforeEach();
+    }
+    
+    @Test
+    void testExpectedMsgRemovedFromQueue() throws Exception {
+        EmailMessage email = new EmailMessage(exchangeService);
+        email.setSubject("Message Succeeded: <jobId>1234</jobId><uuid>aabbcc</uuid>.");
+        List<EmailMessage> emails = Arrays.asList(email);        
+        when(emailService.getInboxEmails()).thenReturn(emails);
+        
+        DocumentDistributionMainProcessProcessResponseDecorator result = new DocumentDistributionMainProcessProcessResponseDecorator();
+        result.setUuid(UUID.randomUUID().toString());
+        result.setJobId("1234");
+        when(emailParser.parse(email)).thenReturn(result);
+        
+        // seed the repo with a single value - an expected email with the given jobId somewhere in the subject or body.
+        SentMessage expectedMsg = new SentMessage();
+        expectedMsg.setJobId(result.getJobId());
+        expectedMsg.setUuid(result.getUuid());
+        expectedMsg.setCreatedTs(DateUtil.addMinutes(new Date(), -10));
+        sentMessageRepository.save(expectedMsg);
+        assertEquals(1, sentMessageRepository.count());  
+        
+        // trigger the scheduled task
+        emailPoller.pollForEmails();
+
+        // assert after polling, the previously inserted redis queue record has been removed.
+        assertEquals(1, sentMessageRepository.count()); 
+    }
+    
+}

--- a/src/test/java/ca/bc/gov/ag/efax/mail/service/parser/UndeliverableVisitorTest.java
+++ b/src/test/java/ca/bc/gov/ag/efax/mail/service/parser/UndeliverableVisitorTest.java
@@ -6,8 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import org.junit.jupiter.api.Test;
 
 import ca.bc.gov.ag.efax.BaseTestSuite;
+import ca.bc.gov.ag.efax.mail.model.DocumentDistributionMainProcessProcessResponseDecorator;
 import ca.bc.gov.ag.efax.ws.exception.FAXSendFault;
-import ca.bc.gov.ag.efax.ws.model.DocumentDistributionMainProcessProcessResponse;
 
 public class UndeliverableVisitorTest extends BaseTestSuite {
 
@@ -15,7 +15,7 @@ public class UndeliverableVisitorTest extends BaseTestSuite {
     void testApply_Success() throws Exception {
         UndeliverableVisitor visitor = new UndeliverableVisitor();
         String subject = "Success: <jobId>1234</jobId><uuid>aabb</uuid>";
-        DocumentDistributionMainProcessProcessResponse response = new DocumentDistributionMainProcessProcessResponse();
+        DocumentDistributionMainProcessProcessResponseDecorator response = new DocumentDistributionMainProcessProcessResponseDecorator();
         visitor.apply(subject, "", response);
 
         // this Undeliverable matcher should not match
@@ -28,10 +28,10 @@ public class UndeliverableVisitorTest extends BaseTestSuite {
     void testApply_Undeliverable() throws Exception {
         UndeliverableVisitor visitor = new UndeliverableVisitor();
         String subject = "Undeliverable: <jobId>1234</jobId><uuid>aabb</uuid>";
-        DocumentDistributionMainProcessProcessResponse response = new DocumentDistributionMainProcessProcessResponse();
+        DocumentDistributionMainProcessProcessResponseDecorator response = new DocumentDistributionMainProcessProcessResponseDecorator();
         visitor.apply(subject, "", response);
 
-        // should match FAXListenFault
+        // should match FAXSendFault
         FAXSendFault fault = new FAXSendFault();
         assertEquals("1234", response.getJobId()); // should have extracted the jobId from the subject
         assertEquals(fault.getFaultCode(), response.getStatusCode());
@@ -42,7 +42,7 @@ public class UndeliverableVisitorTest extends BaseTestSuite {
     void testApply_Mismatch() throws Exception {
         UndeliverableVisitor visitor = new UndeliverableVisitor();
         String subject = "Undeliverable: <jobId>1234</jobId>";
-        DocumentDistributionMainProcessProcessResponse response = new DocumentDistributionMainProcessProcessResponse();
+        DocumentDistributionMainProcessProcessResponseDecorator response = new DocumentDistributionMainProcessProcessResponseDecorator();
         visitor.apply(subject, "", response);
 
         // should not match regex


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

EFAX-24

When a incoming email (a status/receipt msg from MS Exchange of a sent fax) is retrieved from the account's INBOX, the matching record in the redis queue (an list of outstanding receipts not yet received) should be removed.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

mvn test

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
