### PR TITLE
EFAX-24 added Failed and Succeeded visitor parsers

### DIFF
--- a/src/main/java/ca/bc/gov/ag/efax/mail/config/ExchangeConfiguration.java
+++ b/src/main/java/ca/bc/gov/ag/efax/mail/config/ExchangeConfiguration.java
@@ -6,6 +6,8 @@ import org.springframework.context.annotation.Configuration;
 
 import ca.bc.gov.ag.efax.mail.service.ExchangeServiceFactory;
 import ca.bc.gov.ag.efax.mail.service.parser.EmailParser;
+import ca.bc.gov.ag.efax.mail.service.parser.FailedVisitor;
+import ca.bc.gov.ag.efax.mail.service.parser.SucceededVisitor;
 import ca.bc.gov.ag.efax.mail.service.parser.UndeliverableVisitor;
 
 @Configuration
@@ -20,7 +22,9 @@ public class ExchangeConfiguration {
     @Bean
     public EmailParser emailParser() {
         EmailParser emailParser = new EmailParser();
+        emailParser.registerVisitor(new SucceededVisitor());
         emailParser.registerVisitor(new UndeliverableVisitor());
+        emailParser.registerVisitor(new FailedVisitor());
         return emailParser;
     }
 

--- a/src/main/java/ca/bc/gov/ag/efax/mail/service/parser/EmailVisitor.java
+++ b/src/main/java/ca/bc/gov/ag/efax/mail/service/parser/EmailVisitor.java
@@ -1,9 +1,43 @@
 package ca.bc.gov.ag.efax.mail.service.parser;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import ca.bc.gov.ag.efax.mail.model.DocumentDistributionMainProcessProcessResponseDecorator;
+import ca.bc.gov.ag.efax.ws.exception.FAXSendFault;
 
-public interface EmailVisitor {
+public abstract class EmailVisitor {
 
-    public void apply(String subject, String body, DocumentDistributionMainProcessProcessResponseDecorator response);
+    public abstract void apply(String subject, String body, DocumentDistributionMainProcessProcessResponseDecorator response);
+
+    protected Matcher matches(String pattern, String string) {
+        if (Pattern.matches(pattern, string)) {
+            Matcher matcher = Pattern.compile(pattern).matcher(string);
+            if (matcher.find()) {
+                return matcher;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Applies the matcher results and fault code/message to the provided response.
+     */
+    protected void apply(Matcher matcher, FAXSendFault fault, DocumentDistributionMainProcessProcessResponseDecorator response) {
+        response.setJobId(matcher.group(1));
+        response.setUuid(matcher.group(2));
+        response.setStatusCode(fault.getFaultCode());
+        response.setStatusMessage(fault.getFaultMessage());
+    }
+
+    /**
+     * Applies the matcher results and given code/message to the provided response.
+     */
+    protected void apply(Matcher matcher, String statusCode, String statusMessage, DocumentDistributionMainProcessProcessResponseDecorator response) {
+        response.setJobId(matcher.group(1));
+        response.setUuid(matcher.group(2));
+        response.setStatusCode(statusCode);
+        response.setStatusMessage(statusMessage);
+    }
     
 }

--- a/src/main/java/ca/bc/gov/ag/efax/mail/service/parser/FailedVisitor.java
+++ b/src/main/java/ca/bc/gov/ag/efax/mail/service/parser/FailedVisitor.java
@@ -1,0 +1,34 @@
+package ca.bc.gov.ag.efax.mail.service.parser;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ca.bc.gov.ag.efax.mail.model.DocumentDistributionMainProcessProcessResponseDecorator;
+import ca.bc.gov.ag.efax.mail.util.StringUtils;
+import ca.bc.gov.ag.efax.ws.exception.FAXSendFault;
+
+public class FailedVisitor extends EmailVisitor {
+
+    private final static Logger logger = LoggerFactory.getLogger(FailedVisitor.class);
+    
+    /** A regex pattern for the expected subject line of a failed fax */
+    private static final String SUBJECT = "Message Failed: .*";
+    private static final String BODY = ".*<jobId>(\\d+)</jobId><uuid>(.+)</uuid>.*";
+
+    @Override
+    public void apply(String subject, String body, DocumentDistributionMainProcessProcessResponseDecorator response) {
+        if (Pattern.matches(SUBJECT, subject)) {
+            String simplifiedBody = StringUtils.decodeString(body);
+            FAXSendFault fault = new FAXSendFault();            
+            
+            Matcher matcher = matches(BODY, simplifiedBody);
+            if (matcher != null) {
+                apply(matcher, fault, response);
+                logger.error("Undeliverable email, \nsubject: [{}]", subject);
+            }
+        }
+    }
+}

--- a/src/main/java/ca/bc/gov/ag/efax/mail/service/parser/SucceededVisitor.java
+++ b/src/main/java/ca/bc/gov/ag/efax/mail/service/parser/SucceededVisitor.java
@@ -1,0 +1,35 @@
+package ca.bc.gov.ag.efax.mail.service.parser;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ca.bc.gov.ag.efax.mail.model.DocumentDistributionMainProcessProcessResponseDecorator;
+import ca.bc.gov.ag.efax.mail.util.StringUtils;
+
+public class SucceededVisitor extends EmailVisitor {
+
+    private final static Logger logger = LoggerFactory.getLogger(SucceededVisitor.class);
+    
+    /** A regex pattern for the expected subject line of a fax that succeeded. */
+    private static final String SUBJECT = "Message Succeeded: .*";
+    private static final String BODY = ".*<jobId>(\\d+)</jobId><uuid>(.+)</uuid>.*";
+
+    public static final String STATUS_CODE = "SUCC";
+    public static final String STATUS_MESSAGE = "Successful";
+
+    @Override
+    public void apply(String subject, String body, DocumentDistributionMainProcessProcessResponseDecorator response) {
+        if (Pattern.matches(SUBJECT, subject)) {
+            String simplifiedBody = StringUtils.decodeString(body);
+            
+            Matcher matcher = matches(BODY, simplifiedBody);
+            if (matcher != null) {
+                apply(matcher, STATUS_CODE, STATUS_MESSAGE, response);
+                logger.trace("Message Succeeded: jobId:{}", matcher.group(1));
+            }
+        }
+    }
+}

--- a/src/main/java/ca/bc/gov/ag/efax/mail/service/parser/UndeliverableVisitor.java
+++ b/src/main/java/ca/bc/gov/ag/efax/mail/service/parser/UndeliverableVisitor.java
@@ -1,7 +1,6 @@
 package ca.bc.gov.ag.efax.mail.service.parser;
 
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,7 +8,7 @@ import org.slf4j.LoggerFactory;
 import ca.bc.gov.ag.efax.mail.model.DocumentDistributionMainProcessProcessResponseDecorator;
 import ca.bc.gov.ag.efax.ws.exception.FAXSendFault;
 
-public class UndeliverableVisitor implements EmailVisitor {
+public class UndeliverableVisitor extends EmailVisitor {
 
     private final static Logger logger = LoggerFactory.getLogger(UndeliverableVisitor.class);
     
@@ -18,16 +17,13 @@ public class UndeliverableVisitor implements EmailVisitor {
 
     @Override
     public void apply(String subject, String body, DocumentDistributionMainProcessProcessResponseDecorator response) {
-        if (Pattern.matches(UNDELIVERABLE, subject)) {
-            Matcher matcher = Pattern.compile(UNDELIVERABLE).matcher(subject);
-            if (matcher.find()) {
-                FAXSendFault fault = new FAXSendFault();
-                response.setJobId(matcher.group(1));
-                response.setUuid(matcher.group(2));
-                response.setStatusCode(fault.getFaultCode());
-                response.setStatusMessage(fault.getFaultMessage());
-                logger.error("Undeliverable email, \nsubject: [{}]", subject);
-            }
+        FAXSendFault fault = new FAXSendFault();
+        
+        Matcher matcher = matches(UNDELIVERABLE, subject);
+        if (matcher != null) {
+            apply(matcher, fault, response);
+            logger.error("Undeliverable email, \nsubject: [{}]", subject);
         }
     }
+    
 }

--- a/src/main/java/ca/bc/gov/ag/efax/mail/util/StringUtils.java
+++ b/src/main/java/ca/bc/gov/ag/efax/mail/util/StringUtils.java
@@ -20,5 +20,18 @@ public class StringUtils {
             return obj.toString();
         }
 	}
+	
+	/**
+	 * A helper method to remove all carriage returns and replace all escaped < > symbols.
+	 * @param str
+	 */
+	public static String decodeString(String str) {
+	    if (str == null) {
+	        str = "";
+	    }
+	    return str
+            .replaceAll("\\r", "").replaceAll("\\n", "")
+            .replaceAll("&lt;", "<").replaceAll("&gt;", ">");
+	}
 
 }

--- a/src/test/java/ca/bc/gov/ag/efax/mail/service/parser/FailedVisitorTest.java
+++ b/src/test/java/ca/bc/gov/ag/efax/mail/service/parser/FailedVisitorTest.java
@@ -1,0 +1,44 @@
+package ca.bc.gov.ag.efax.mail.service.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+import ca.bc.gov.ag.efax.BaseTestSuite;
+import ca.bc.gov.ag.efax.mail.model.DocumentDistributionMainProcessProcessResponseDecorator;
+import ca.bc.gov.ag.efax.ws.exception.FAXSendFault;
+
+public class FailedVisitorTest extends BaseTestSuite {
+
+    @Test
+    void testApply_Success() throws Exception {
+        FailedVisitor visitor = new FailedVisitor();
+        String subject = "Message Succeeded: 2505551234 (2505551234@somewhere.com) on 8/13/2021 at 12:38:15 PM";
+        String body = "Your fax which was sent to 2505551234@somewhere.com at 2505551234 with subject <jobId>123</jobId><uuid>8e3b47c4-60b6-43e7-81ee- c9ac5930e49d</uuid> was delivered successfully";
+        DocumentDistributionMainProcessProcessResponseDecorator response = new DocumentDistributionMainProcessProcessResponseDecorator();
+        visitor.apply(subject, body, response);
+
+        // this Failed matcher should not match
+        assertNull(response.getJobId());
+        assertNull(response.getStatusCode());
+        assertNull(response.getStatusMessage());                
+    }
+
+    @Test
+    void testApply_Failed() throws Exception {
+        FailedVisitor visitor = new FailedVisitor();
+        String subject = "Message Failed: 2505551234 - Failed (The transmission was disconnected while in progress.)";
+        String body = "Your fax which was sent to 2505551234@somewhere.com at 2505551234 with subject <jobId>1234</jobId><uuid>070d08c0-8704-4232-b5e2- cc23b377433f</uuid> on 8/13/2021 at 11:17:41 AM, failed to be delivered";
+        DocumentDistributionMainProcessProcessResponseDecorator response = new DocumentDistributionMainProcessProcessResponseDecorator();
+        visitor.apply(subject, body, response);
+
+        // should match FAXSendFault
+        FAXSendFault fault = new FAXSendFault();
+        assertEquals("1234", response.getJobId()); // should have extracted the jobId from the body
+        assertEquals("070d08c0-8704-4232-b5e2- cc23b377433f", response.getUuid()); // should have extracted the jobId from the body
+        assertEquals(fault.getFaultCode(), response.getStatusCode());
+        assertEquals(fault.getFaultMessage(), response.getStatusMessage());              
+    }
+    
+}

--- a/src/test/java/ca/bc/gov/ag/efax/mail/service/parser/SucceededVisitorTest.java
+++ b/src/test/java/ca/bc/gov/ag/efax/mail/service/parser/SucceededVisitorTest.java
@@ -1,0 +1,42 @@
+package ca.bc.gov.ag.efax.mail.service.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+import ca.bc.gov.ag.efax.BaseTestSuite;
+import ca.bc.gov.ag.efax.mail.model.DocumentDistributionMainProcessProcessResponseDecorator;
+
+public class SucceededVisitorTest extends BaseTestSuite {
+
+    @Test
+    void testApply_Success() throws Exception {
+        SucceededVisitor visitor = new SucceededVisitor();
+        String subject = "Message Succeeded: 2505551234 (2505551234@somewhere.com) on 8/13/2021 at 12:38:15 PM";
+        String body = "Your fax which was sent to 2505551234@somewhere.com at 2505551234 with subject <jobId>1234</jobId><uuid>8e3b47c4-60b6-43e7-81ee- c9ac5930e49d</uuid> was delivered successfully";
+        DocumentDistributionMainProcessProcessResponseDecorator response = new DocumentDistributionMainProcessProcessResponseDecorator();
+        visitor.apply(subject, body, response);
+        
+        // should match FAXSendFault
+        assertEquals("1234", response.getJobId()); // should have extracted the jobId from the body
+        assertEquals("8e3b47c4-60b6-43e7-81ee- c9ac5930e49d", response.getUuid()); // should have extracted the jobId from the body
+        assertEquals(SucceededVisitor.STATUS_CODE, response.getStatusCode());
+        assertEquals(SucceededVisitor.STATUS_MESSAGE, response.getStatusMessage());            
+    }
+
+    @Test
+    void testApply_Failed() throws Exception {
+        SucceededVisitor visitor = new SucceededVisitor();
+        String subject = "Message Failed: 2505551234 - Failed (The transmission was disconnected while in progress.)";
+        String body = "Your fax which was sent to 2505551234@somewhere.com at 2505551234 with subject <jobId>1234</jobId><uuid>070d08c0-8704-4232-b5e2- cc23b377433f</uuid> on 8/13/2021 at 11:17:41 AM, failed to be delivered";
+        DocumentDistributionMainProcessProcessResponseDecorator response = new DocumentDistributionMainProcessProcessResponseDecorator();
+        visitor.apply(subject, body, response);
+
+        // this Failed matcher should not match
+        assertNull(response.getJobId());
+        assertNull(response.getStatusCode());
+        assertNull(response.getStatusMessage());              
+    }
+    
+}

--- a/src/test/java/ca/bc/gov/ag/efax/mail/service/parser/SucceededVisitorTest.java
+++ b/src/test/java/ca/bc/gov/ag/efax/mail/service/parser/SucceededVisitorTest.java
@@ -20,7 +20,7 @@ public class SucceededVisitorTest extends BaseTestSuite {
         
         // should match FAXSendFault
         assertEquals("1234", response.getJobId()); // should have extracted the jobId from the body
-        assertEquals("8e3b47c4-60b6-43e7-81ee- c9ac5930e49d", response.getUuid()); // should have extracted the jobId from the body
+        assertEquals("8e3b47c4-60b6-43e7-81ee-c9ac5930e49d", response.getUuid()); // should have extracted the jobId from the body
         assertEquals(SucceededVisitor.STATUS_CODE, response.getStatusCode());
         assertEquals(SucceededVisitor.STATUS_MESSAGE, response.getStatusMessage());            
     }

--- a/src/test/java/ca/bc/gov/ag/efax/mail/service/parser/SucceededVisitorTest.java
+++ b/src/test/java/ca/bc/gov/ag/efax/mail/service/parser/SucceededVisitorTest.java
@@ -14,7 +14,7 @@ public class SucceededVisitorTest extends BaseTestSuite {
     void testApply_Success() throws Exception {
         SucceededVisitor visitor = new SucceededVisitor();
         String subject = "Message Succeeded: 2505551234 (2505551234@somewhere.com) on 8/13/2021 at 12:38:15 PM";
-        String body = "Your fax which was sent to 2505551234@somewhere.com at 2505551234 with subject <jobId>1234</jobId><uuid>8e3b47c4-60b6-43e7-81ee- c9ac5930e49d</uuid> was delivered successfully";
+        String body = "Your fax which was sent to 2505551234@somewhere.com at 2505551234 with subject <jobId>1234</jobId><uuid>8e3b47c4-60b6-43e7-81ee-c9ac5930e49d</uuid> was delivered successfully";
         DocumentDistributionMainProcessProcessResponseDecorator response = new DocumentDistributionMainProcessProcessResponseDecorator();
         visitor.apply(subject, body, response);
         
@@ -29,7 +29,7 @@ public class SucceededVisitorTest extends BaseTestSuite {
     void testApply_Failed() throws Exception {
         SucceededVisitor visitor = new SucceededVisitor();
         String subject = "Message Failed: 2505551234 - Failed (The transmission was disconnected while in progress.)";
-        String body = "Your fax which was sent to 2505551234@somewhere.com at 2505551234 with subject <jobId>1234</jobId><uuid>070d08c0-8704-4232-b5e2- cc23b377433f</uuid> on 8/13/2021 at 11:17:41 AM, failed to be delivered";
+        String body = "Your fax which was sent to 2505551234@somewhere.com at 2505551234 with subject <jobId>1234</jobId><uuid>070d08c0-8704-4232-b5e2-cc23b377433f</uuid> on 8/13/2021 at 11:17:41 AM, failed to be delivered";
         DocumentDistributionMainProcessProcessResponseDecorator response = new DocumentDistributionMainProcessProcessResponseDecorator();
         visitor.apply(subject, body, response);
 

--- a/src/test/java/ca/bc/gov/ag/efax/mail/util/StringUtilsTest.java
+++ b/src/test/java/ca/bc/gov/ag/efax/mail/util/StringUtilsTest.java
@@ -1,0 +1,20 @@
+package ca.bc.gov.ag.efax.mail.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class StringUtilsTest {
+
+    @Test
+    void testDecodeString() throws Exception {
+        assertEquals("", StringUtils.decodeString(null));
+        assertEquals("", StringUtils.decodeString(""));
+        assertEquals("asdf", StringUtils.decodeString("asdf"));
+        assertEquals("line1line2", StringUtils.decodeString("line1\r\nline2"));
+        assertEquals("line1\tline2", StringUtils.decodeString("line1\tline2"));
+        assertEquals("<jobId></jobId>", StringUtils.decodeString("<jobId></jobId>"));
+        assertEquals("<jobId></jobId>", StringUtils.decodeString("&lt;jobId&gt;&lt;/jobId&gt;"));
+    }
+    
+}


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

EFAX-24

This PR will add the ability to correctly parse incoming emails from Exchange (receipts of send faxes).  These emails are formatted of the form:

`Message Succeeded: 2505551234 (2505551234@somewhere.com) `
or
`Message Failed: 2505551234 - Failed (The transmission was disconnected while in progress.)`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

mvn test
docker-compose up -d --build

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
