### PR TITLE
NPE fix - under heavy load redis may return null

### DIFF
--- a/src/main/java/ca/bc/gov/ag/efax/ws/scheduled/ScheduledTasks.java
+++ b/src/main/java/ca/bc/gov/ag/efax/ws/scheduled/ScheduledTasks.java
@@ -64,6 +64,10 @@ public class ScheduledTasks {
      * Returns true of the queued redis message has timed out (ie, created > 25 minutes ago)
      */
     private boolean hasTimedOut(SentMessage sentMessage) {
+        // NPE fix.  For some reason under heavy load redis can return null records.
+        if (sentMessage == null) {            
+            return false;
+        }
         long now = new Date().getTime();
         Date createdTs = sentMessage.getCreatedTs();
         return createdTs.getTime() + faxTimeout < now;


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

NPE fix - under load testing, it appears that sometimes redis will return null.
Apparently, `sentMessageRepository.findAll()` can sometimes return null records.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
