### PR TITLE
Added arg var to enable splunk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,17 @@
 FROM maven:3.8.1-openjdk-11 as build
 
 ARG SKIP_TESTS=false
+ARG ENABLE_SPLUNK=false
 
 WORKDIR /
 
 COPY . .
 
+RUN echo ENABLE_SPLUNK=${ENABLE_SPLUNK}
+
 RUN mvn -B clean package \
-        -Dmaven.test.skip=${SKIP_TESTS}
+        -Dmaven.test.skip=${SKIP_TESTS} \
+        -Denable-splunk=${ENABLE_SPLUNK}
 
 
 #############################################################################################

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       dockerfile: Dockerfile
       args:
         - SKIP_TESTS=true
+        - ENABLE_SPLUNK=${ENABLE_SPLUNK:-false}
     ports:
       - "8080:8080"
     environment:

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,12 @@
 		</profile>
 		<profile>
 			<id>splunk</id>
+			<activation>
+				<property>
+					<name>enable-splunk</name>
+					<value>true</value>
+				</property>
+			</activation>
 			<repositories>
 				<repository>
 					<id>splunk-artifactory</id>


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

Added a splunk arg to Docker so it can include the splunk libraries when building (enables the splunk profile)

when running locally:
```
SET ENABLE_SPLUNK=true
docker-compose build webservice
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [x] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [x] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
