### PR TITLE
Set flattening flag to 96, which should send back original if failure

### DIFF
--- a/src/main/java/ca/bc/gov/ag/efax/pdf/service/PdfService.java
+++ b/src/main/java/ca/bc/gov/ag/efax/pdf/service/PdfService.java
@@ -54,7 +54,7 @@ public class PdfService extends WebServiceGatewaySupport {
                 String encoded = Base64.getEncoder().encodeToString(data);
     
                 PDFTransformations request = new PDFTransformations();
-                request.setFlags(3);
+                request.setFlags(96);
                 request.setInputFile(encoded);
                 
                 JAXBElement<PDFTransformationsResponse> jaxbResponse = (JAXBElement<PDFTransformationsResponse>) getWebServiceTemplate()


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

Per review from John Revoy, set flattening flag to 96, which should send back the original pdf if there was an error.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
