### PR TITLE
EFAX-78 CVE-2021-44228 log4j fix to use 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
 	<properties>
 		<java.version>1.8</java.version>
 		<main.basedir>${project.basedir}</main.basedir>
+		<log4j2.version>2.15.0</log4j2.version>
 	</properties>
 
 	<repositories>


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

EFAX-78 CVE-2021-44228 log4j fix to use 2.15.0
https://access.redhat.com/security/cve/cve-2021-44228

This PR simply bumps the version of log4j from 2.14.1 to 2.15.0

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [x] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
