### PR TITLE
EFAX-79 CVE-2021-45046 log4j fix to use 2.16.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ FROM openjdk:8-jdk-slim
 
 ARG MODULE=
 
-COPY --from=build ./target/jag-efax-1.0.1.jar /app/service.jar
+COPY --from=build ./target/jag-efax-1.0.2.jar /app/service.jar
 
 CMD ["java", "-jar", "/app/service.jar"]
 #############################################################################################

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
 	<groupId>ca.bc.gov.ag</groupId>
 	<artifactId>jag-efax</artifactId>
-	<version>1.0.1</version>
+	<version>1.0.2</version>
 
 	<name>jag-eFax</name>
 	<description>A BPEL eFax Replacement project.</description>
@@ -18,7 +18,7 @@
 	<properties>
 		<java.version>1.8</java.version>
 		<main.basedir>${project.basedir}</main.basedir>
-		<log4j2.version>2.15.0</log4j2.version>
+		<log4j2.version>2.16.0</log4j2.version>
 	</properties>
 
 	<repositories>


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

EFAX-79 
- upgrade log4j to 2.16.0
- bump pom.xml version to 1.0.2 in preparation for release

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [x] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [x] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [x] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
