### PR TITLE
Bumped version in main to 1.1.0-SNAPSHOT

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
+.git
 target

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #############################################################################################
 ###              Stage where Docker is building spring boot app using maven               ###
 #############################################################################################
-FROM maven:3.8.1-openjdk-11 as build
+FROM maven:3.8.1-openjdk-8 as build
 
 ARG SKIP_TESTS=false
 ARG ENABLE_SPLUNK=false
@@ -13,9 +13,9 @@ COPY . .
 RUN echo ENABLE_SPLUNK=${ENABLE_SPLUNK}
 
 RUN mvn -B clean package \
+        -Dtarget.fileName=jag-efax \
         -Dmaven.test.skip=${SKIP_TESTS} \
         -Denable-splunk=${ENABLE_SPLUNK}
-
 
 #############################################################################################
 ### Stage where Docker is running a java process to run a service built in previous stage ###
@@ -24,7 +24,7 @@ FROM openjdk:8-jdk-slim
 
 ARG MODULE=
 
-COPY --from=build ./target/jag-efax-1.0.3.jar /app/service.jar
+COPY --from=build ./target/jag-efax.jar /app/service.jar
 
 CMD ["java", "-jar", "/app/service.jar"]
 #############################################################################################

--- a/pom.xml
+++ b/pom.xml
@@ -10,12 +10,13 @@
 
 	<groupId>ca.bc.gov.ag</groupId>
 	<artifactId>jag-efax</artifactId>
-	<version>1.0.3</version>
+	<version>1.1.0-SNAPSHOT</version>
 
 	<name>jag-eFax</name>
 	<description>A BPEL eFax Replacement project.</description>
 
 	<properties>
+	    <target.fileName>${project.artifactId}-${project.version}</target.fileName>
 		<java.version>1.8</java.version>
 		<main.basedir>${project.basedir}</main.basedir>
 		<log4j2.version>2.16.0</log4j2.version>
@@ -134,6 +135,7 @@
 	</profiles>
 
 	<build>
+		<finalName>${target.fileName}</finalName>
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Bumped version in main to 1.1.0-SNAPSHOT following release.
- Simplified versioning so it's only specified in ONE place (pom.xml), not 2 places.
- Fixed Dockerfile so the JDK while building the same version as runtime - it was building using jdk11, but running with jdk8

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [x] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [x] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [x] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
