### PR TITLE
Fixed Dockerfile. Build JDK should be the same as Runtime JDK.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #############################################################################################
 ###              Stage where Docker is building spring boot app using maven               ###
 #############################################################################################
-FROM maven:3.8.1-openjdk-11 as build
+FROM maven:3.8.1-openjdk-8 as build
 
 ARG SKIP_TESTS=false
 ARG ENABLE_SPLUNK=false


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

Fixed Dockerfile. 
Build JDK (was JDK11) should match the runtime of JDK8

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [x] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [x] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [x] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
