### PR TITLE
Made the build target filename static, not changing with the pom version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
+.git
 target

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,9 @@ COPY . .
 RUN echo ENABLE_SPLUNK=${ENABLE_SPLUNK}
 
 RUN mvn -B clean package \
+        -Dtarget.fileName=jag-efax \
         -Dmaven.test.skip=${SKIP_TESTS} \
         -Denable-splunk=${ENABLE_SPLUNK}
-
 
 #############################################################################################
 ### Stage where Docker is running a java process to run a service built in previous stage ###
@@ -24,7 +24,7 @@ FROM openjdk:8-jdk-slim
 
 ARG MODULE=
 
-COPY --from=build ./target/jag-efax-1.0.3.jar /app/service.jar
+COPY --from=build ./target/jag-efax.jar /app/service.jar
 
 CMD ["java", "-jar", "/app/service.jar"]
 #############################################################################################

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
 	<description>A BPEL eFax Replacement project.</description>
 
 	<properties>
+		<target.fileName>${project.artifactId}-${project.version}</target.fileName>
 		<java.version>1.8</java.version>
 		<main.basedir>${project.basedir}</main.basedir>
 		<log4j2.version>2.16.0</log4j2.version>
@@ -134,6 +135,7 @@
 	</profiles>
 
 	<build>
+		<finalName>${target.fileName}</finalName>
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

The target filename is now jag-efax.jar, not suffixed with the pom version that changes all the time.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [x] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [x] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
